### PR TITLE
feat: make `talosconfig` and `talosconfigtemplate` immutable

### DIFF
--- a/api/v1alpha3/talosconfig_webhook.go
+++ b/api/v1alpha3/talosconfig_webhook.go
@@ -7,6 +7,7 @@ package v1alpha3
 import (
 	"fmt"
 
+	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -21,7 +22,7 @@ func (r *TalosConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-bootstrap-cluster-x-k8s-io-v1alpha3-talosconfig,mutating=false,failurePolicy=fail,groups=bootstrap.cluster.x-k8s.io,resources=talosconfigs,versions=v1alpha3,name=vtalosconfig.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1
+//+kubebuilder:webhook:verbs=create;update,path=/validate-bootstrap-cluster-x-k8s-io-v1alpha3-talosconfig,mutating=false,failurePolicy=fail,groups=bootstrap.cluster.x-k8s.io,resources=talosconfigs,versions=v1alpha3,name=vtalosconfig.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1
 
 var _ webhook.Validator = &TalosConfig{}
 
@@ -31,7 +32,13 @@ func (r *TalosConfig) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *TalosConfig) ValidateUpdate(old runtime.Object) error {
+func (r *TalosConfig) ValidateUpdate(oldRaw runtime.Object) error {
+	old := oldRaw.(*TalosConfig)
+
+	if !cmp.Equal(r.Spec, old.Spec) {
+		return apierrors.NewBadRequest("TalosConfig.Spec is immutable")
+	}
+
 	return r.validate()
 }
 

--- a/api/v1alpha3/talosconfigtemplate_webhook.go
+++ b/api/v1alpha3/talosconfigtemplate_webhook.go
@@ -5,11 +5,40 @@
 package v1alpha3
 
 import (
+	"github.com/google/go-cmp/cmp"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 func (r *TalosConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
+}
+
+//+kubebuilder:webhook:verbs=update,path=/validate-bootstrap-cluster-x-k8s-io-v1alpha3-talosconfigtemplate,mutating=false,failurePolicy=fail,groups=bootstrap.cluster.x-k8s.io,resources=talosconfigtemplates,versions=v1alpha3,name=vtalosconfigtemplate.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1
+
+var _ webhook.Validator = &TalosConfigTemplate{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *TalosConfigTemplate) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *TalosConfigTemplate) ValidateUpdate(oldRaw runtime.Object) error {
+	old := oldRaw.(*TalosConfigTemplate)
+
+	if !cmp.Equal(r.Spec, old.Spec) {
+		return apierrors.NewBadRequest("TalosConfigTemplate.Spec is immutable")
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *TalosConfigTemplate) ValidateDelete() error {
+	return nil
 }

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -22,7 +22,25 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     resources:
     - talosconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-bootstrap-cluster-x-k8s-io-v1alpha3-talosconfigtemplate
+  failurePolicy: Fail
+  name: vtalosconfigtemplate.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - UPDATE
+    resources:
+    - talosconfigtemplates
   sideEffects: None

--- a/internal/integration/setup_test.go
+++ b/internal/integration/setup_test.go
@@ -95,6 +95,9 @@ func setupSuite(t *testing.T) (context.Context, client.Client) {
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 10})
 	require.NoError(t, err)
 
+	err = (&bootstrapv1alpha3.TalosConfigTemplate{}).SetupWebhookWithManager(mgr)
+	require.NoError(t, err)
+
 	err = (&bootstrapv1alpha3.TalosConfig{}).SetupWebhookWithManager(mgr)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This change is made to conform CAPI practices for resource updates:
instead of modifying the templates/configs, it is necessary to create a
new one.

If the resource is always recreated, rolling update strategy will be
able to pick up the change and redeploy machines.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>