### PR TITLE
feat: add Tilt support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ talosctl
 talosconfig
 kubeconfig
 coverage.txt
+
+# Tilt build files
+.tiltbuild

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
 - manager.yaml
+images:
+- name: controller
+  newName: ghcr.io/siderolabs/cluster-api-talos-controller

--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -1,0 +1,17 @@
+{
+    "name": "talos-bootstrap",
+    "config": {
+      "image": "ghcr.io/siderolabs/cluster-api-talos-controller",
+      "live_reload_deps": [
+        "main.go",
+        "go.mod",
+        "go.sum",
+        "api",
+        "config",
+        "controllers",
+        "internal",
+        "pkg"
+      ],
+      "label": "CABPT"
+    }
+}


### PR DESCRIPTION
This adds the support for [Tilt](https://tilt.dev), as described in https://cluster-api.sigs.k8s.io/developer/tilt.html#tilt-provider-configuration


Signed-off-by: Benjamin Gentil <benjamin.gentil@infomaniak.com>