### PR TITLE
Talos reset lifecycle hook

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,11 +42,19 @@ rules:
   resources:
   - clusters
   - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
   - machines
   - machines/status
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - exp.cluster.x-k8s.io

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -1,0 +1,165 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	machine2 "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"time"
+
+	"github.com/go-logr/logr"
+	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/predicates"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// MachineReconciler reconciles a Machine object
+type MachineReconciler struct {
+	client.Client
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	WatchFilterValue string
+}
+
+var MachineHookAnnotationTalosReset = capiv1.PreTerminateDeleteHookAnnotationPrefix + "/talos-reset"
+
+func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	r.Scheme = mgr.GetScheme()
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&capiv1.Machine{}).
+		WithOptions(options).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		Complete(r)
+}
+
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get
+
+func (r *MachineReconciler) Reconcile(ctx context.Context, req reconcile.Request) (_ reconcile.Result, rerr error) {
+	log := r.Log.WithName(controllerName).
+		WithName(fmt.Sprintf("namespace=%s", req.Namespace)).
+		WithName(fmt.Sprintf("machine=%s", req.Name))
+
+	// Lookup the talosconfig config
+	machine := &capiv1.Machine{}
+	if err := r.Client.Get(ctx, req.NamespacedName, machine); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "Failed to get machine.")
+		return ctrl.Result{}, err
+	}
+
+	// Initialize the patch helper
+	patchHelper, err := patch.NewHelper(machine, r.Client)
+	if err != nil {
+		log.Error(err, "Could not create a patchHelper for config.")
+		return ctrl.Result{}, err
+	}
+
+	// Patch machine after each reconciliation
+	defer func() {
+		if err := patchHelper.Patch(ctx, machine); err != nil {
+			log.Error(err, "Failed to patch machine.")
+			if rerr == nil {
+				rerr = err
+			}
+		}
+	}()
+
+	preTerminateDeleteHookCondition := conditions.Get(machine, capiv1.PreTerminateDeleteHookSucceededCondition)
+	if !machine.ObjectMeta.DeletionTimestamp.IsZero() &&
+		annotations.HasWithPrefix(MachineHookAnnotationTalosReset, machine.ObjectMeta.Annotations) &&
+		preTerminateDeleteHookCondition != nil &&
+		preTerminateDeleteHookCondition.Status == corev1.ConditionFalse {
+		return r.resetMachine(ctx, machine)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *MachineReconciler) resetMachine(ctx context.Context, machine *capiv1.Machine) (reconcile.Result, error) {
+	log := r.Log.WithName(controllerName).
+		WithName(fmt.Sprintf("namespace=%s", machine.GetNamespace())).
+		WithName(fmt.Sprintf("machine=%s", machine.GetName()))
+
+	talosClient, err := r.talosconfigForMachine(ctx, machine)
+	if err != nil {
+		log.Error(err, "Could not create talos client for machine")
+		return reconcile.Result{Requeue: true}, err
+	}
+
+	defer talosClient.Close() //nolint:errcheck
+
+	var address string
+
+	// Prefer finding an InternalIP address for the machine first.
+	// Fallback to finding an ExternalIP address for the machine
+	// if no InternalIP is found.
+	for _, addr := range machine.Status.Addresses {
+		if addr.Type == capiv1.MachineInternalIP {
+			address = addr.Address
+			break
+		}
+		if addr.Type == capiv1.MachineExternalIP {
+			address = addr.Address
+		}
+	}
+
+	if address == "" {
+		log.Error(nil, "No node addresses were found. Assuming node was never provisioned.")
+		delete(machine.ObjectMeta.Annotations, MachineHookAnnotationTalosReset)
+		return reconcile.Result{}, nil
+	}
+
+	ctxTimeout, ctxCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer ctxCancel()
+
+	err = talosClient.ResetGeneric(talosclient.WithNode(ctxTimeout, address), &machine2.ResetRequest{
+		Graceful: true,
+		Reboot:   false,
+	})
+	if err != nil {
+		log.Info("Failed to send Talos reset request to machine. Assuming node is already reset.")
+		delete(machine.ObjectMeta.Annotations, MachineHookAnnotationTalosReset)
+		return reconcile.Result{}, nil
+	}
+	log.Info("Talos node reset request successfully sent.")
+	return reconcile.Result{RequeueAfter: 15 * time.Second}, nil
+}
+
+func (r *MachineReconciler) talosconfigForMachine(ctx context.Context, machine *capiv1.Machine) (*talosclient.Client, error) {
+	var (
+		talosconfigSecret corev1.Secret
+		clusterName       = machine.GetLabels()["cluster.x-k8s.io/cluster-name"]
+	)
+
+	if err := r.Client.Get(ctx,
+		types.NamespacedName{
+			Namespace: machine.GetNamespace(),
+			Name:      clusterName + "-talosconfig",
+		},
+		&talosconfigSecret,
+	); err != nil {
+		return nil, err
+	}
+
+	t, err := talosconfig.FromBytes(talosconfigSecret.Data["talosconfig"])
+	if err != nil {
+		return nil, err
+	}
+
+	return talosclient.New(ctx, talosclient.WithConfig(t))
+}

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -8,7 +8,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/siderolabs/cluster-api-bootstrap-provider-talos/controllers"
 	"os"
+	bsutil "sigs.k8s.io/cluster-api/bootstrap/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"strconv"
 	"strings"
 	"testing"
@@ -203,6 +206,11 @@ func waitForReady(ctx context.Context, t *testing.T, c client.Client, talosConfi
 	}
 
 	assert.True(t, conditions.IsTrue(talosConfig, bootstrapv1alpha3.DataSecretAvailableCondition))
+
+	machine, err := bsutil.GetConfigOwner(ctx, c, talosConfig)
+	require.NoError(t, err)
+
+	assert.True(t, annotations.HasWithPrefix(controllers.MachineHookAnnotationTalosReset, machine.GetAnnotations()))
 
 	if talosConfig.Spec.GenerateType == talosmachine.TypeInit.String() || talosConfig.Spec.GenerateType == talosmachine.TypeControlPlane.String() {
 		// wait for additional condition

--- a/main.go
+++ b/main.go
@@ -110,6 +110,15 @@ func setupReconcilers(ctx context.Context, mgr manager.Manager) {
 		setupLog.Error(err, "unable to create controller", "controller", "TalosConfig")
 		os.Exit(1)
 	}
+	if err := (&controllers.MachineReconciler{
+		Client:           mgr.GetClient(),
+		Log:              ctrl.Log.WithName("controllers").WithName("Machine"),
+		Scheme:           mgr.GetScheme(),
+		WatchFilterValue: watchFilterValue,
+	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 10}); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Machine")
+		os.Exit(1)
+	}
 }
 
 func setupWebhooks(mgr manager.Manager) {


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/issues/159

This feature makes use of the [CAPI pre-terminate hook](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20200602-machine-deletion-phase-hooks.md#pre-terminate), which is implemented in CAPI [here](https://github.com/kubernetes-sigs/cluster-api/blob/main/internal/controllers/machine/machine_controller.go#L386).

The hook just waits until all annotations prefixed with `pre-terminate.delete.hook.machine.cluster.x-k8s.io` are removed before it allows the Machine to be deleted from the infrastructure provider (i.e.: VM is removed from cloud provider).

This MR does the following:

-  adds the `pre-terminate.delete.hook.machine.cluster.x-k8s.io/talos-reset: cabpt-controller` annotation to the machines which are being provisioned
-  implements the machine_controller, which resets the Talos node when a machine is being deleted and removes the annotation after this is done, so that the VM can be deleted.
	- If this fails due to any reason (node is down/not reachable) it will still remove the annotation and continue deleting the machine
