### PR TITLE
chore: add 0.6 series to CAPI metadata

### DIFF
--- a/config/metadata/metadata.yaml
+++ b/config/metadata/metadata.yaml
@@ -13,3 +13,6 @@ releaseSeries:
 - major: 0
   minor: 5
   contract: v1beta1
+- major: 0
+  minor: 6
+  contract: v1beta1


### PR DESCRIPTION
This should fix the installation process.