### PR TITLE
fix: update Talos machinery to 1.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TEST_RUN ?= ./...
 
 TOOLS ?= ghcr.io/siderolabs/tools:v1.5.0
 PKGS ?= v1.5.0
-TALOS_VERSION ?= v1.5.0
+TALOS_VERSION ?= v1.5.2
 K8S_VERSION ?= 1.27.4
 
 CONTROLLER_GEN_VERSION ?= v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/siderolabs/crypto v0.4.1
 	github.com/siderolabs/go-pointer v1.0.0
-	github.com/siderolabs/talos/pkg/machinery v1.5.0
+	github.com/siderolabs/talos/pkg/machinery v1.5.2
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/sys v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,8 @@ github.com/siderolabs/go-pointer v1.0.0/go.mod h1:HTRFUNYa3R+k0FFKNv11zgkaCLzEkW
 github.com/siderolabs/net v0.4.0 h1:1bOgVay/ijPkJz4qct98nHsiB/ysLQU0KLoBC4qLm7I=
 github.com/siderolabs/net v0.4.0/go.mod h1:/ibG+Hm9HU27agp5r9Q3eZicEfjquzNzQNux5uEk0kM=
 github.com/siderolabs/protoenc v0.2.0 h1:QFxWIAo//12+/bm27GNYoK/TpQGTYsRrrZCu9jSghvU=
-github.com/siderolabs/talos/pkg/machinery v1.5.0 h1:yWRYcMKSkdDhumYnSnv/HndJ/S7AYl2/JcwkHWwB1So=
-github.com/siderolabs/talos/pkg/machinery v1.5.0/go.mod h1:7Mmswfab95ULNclTI4ZGR8hZaQyrjDVfSyYGVECgFBs=
+github.com/siderolabs/talos/pkg/machinery v1.5.2 h1:XENjTuWdcCSgmPK6HsN81RAzN0T9mD8VjaRPM1pQMB8=
+github.com/siderolabs/talos/pkg/machinery v1.5.2/go.mod h1:7Mmswfab95ULNclTI4ZGR8hZaQyrjDVfSyYGVECgFBs=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=


### PR DESCRIPTION
This brings in a fix for `talosconfig` lifetime.