### PR TITLE
fix: add metrics port to manager container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,7 +19,7 @@ spec:
         - command:
             - /manager
           args:
-            - --metrics-bind-addr=127.0.0.1:8080
+            - --metrics-bind-addr=0.0.0.0:8080
             - --enable-leader-election
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}"
           image: controller:latest
@@ -28,6 +28,9 @@ spec:
           ports:
             - containerPort: 9440
               name: healthz
+              protocol: TCP
+            - containerPort: 8080
+              name: metrics
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: system
 spec:
   ports:
-  - name: https
+  - name: metrics
     port: 8443
-    targetPort: https
+    targetPort: metrics
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
The `controller-manager-metrics-service` expects an `https` port on the container to expose