### PR TITLE
feat: support for strategic merge patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,15 @@ spec:
 Machine configuration can be customized by applying configuration patches.
 Any field of the [Talos machine configuration](https://www.talos.dev/docs/latest/reference/configuration/)
 can be overridden on a per-machine basis using this method.
-The format of these patches is based on [JSON 6902](http://jsonpatch.com/) that you may be used to in tools like `kustomize`.
+
+There are two [patch formats](https://www.talos.dev/latest/talos-guides/configuration/patching/) supported by CABPT:
+
+- the [JSON 6902](http://jsonpatch.com/) format that you may be used to in tools like `kustomize`;
+- strategic merge patches which look like incomplete machine configuration documents.
+
+See Talos Linux documentation for more information on patching.
+
+JSON 6902 patch:
 
 ```yaml
 spec:
@@ -162,6 +170,26 @@ spec:
         name: custom
         urls:
           - https://docs.projectcalico.org/v3.18/manifests/calico.yaml
+```
+
+Strategic merge patch:
+
+```yaml
+spec:
+  generateType: controlplane
+  talosVersion: v1.6
+  strategicPatches:
+    - |
+      machine:
+        install:
+          disk: /dev/sda
+    - |
+      cluster:
+        network:
+          cni:
+            name: custom
+            urls:
+              - https://docs.projectcalico.org/v3.18/manifests/calico.yaml
 ```
 
 ### Retrieving `talosconfig`

--- a/api/v1alpha3/talosconfig_types.go
+++ b/api/v1alpha3/talosconfig_types.go
@@ -20,6 +20,8 @@ type TalosConfigSpec struct {
 	GenerateType  string          `json:"generateType"`           //none,init,controlplane,worker mutually exclusive w/ data
 	Data          string          `json:"data,omitempty"`
 	ConfigPatches []ConfigPatches `json:"configPatches,omitempty"`
+	// Talos Linux machine configuration strategic merge patch list.
+	StrategicPatches []string `json:"strategicPatches,omitempty"`
 	// Set hostname in the machine configuration to some value.
 	Hostname HostnameSpec `json:"hostname,omitempty"`
 	// Important: Run "make" to regenerate code after modifying this file

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -113,6 +113,11 @@ func (in *TalosConfigSpec) DeepCopyInto(out *TalosConfigSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.StrategicPatches != nil {
+		in, out := &in.StrategicPatches, &out.StrategicPatches
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.Hostname = in.Hostname
 }
 

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_talosconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_talosconfigs.yaml
@@ -129,6 +129,12 @@ spec:
                       Allowed values: "MachineName" (use linked Machine's Name).
                     type: string
                 type: object
+              strategicPatches:
+                description: Talos Linux machine configuration strategic merge patch
+                  list.
+                items:
+                  type: string
+                type: array
               talosVersion:
                 type: string
             required:

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_talosconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_talosconfigtemplates.yaml
@@ -124,6 +124,12 @@ spec:
                               Allowed values: "MachineName" (use linked Machine's Name).
                             type: string
                         type: object
+                      strategicPatches:
+                        description: Talos Linux machine configuration strategic merge
+                          patch list.
+                        items:
+                          type: string
+                        type: array
                       talosVersion:
                         type: string
                     required:

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -6,7 +6,7 @@ github_repo = "siderolabs/cluster-api-bootstrap-provider-talos"
 match_deps = "^github.com/(siderolabs/[a-zA-Z0-9-]+)$"
 
 # previous release
-previous = "v0.6.3"
+previous = "v0.6.4"
 
 pre_release = false
 
@@ -15,3 +15,8 @@ preface = """\
 
 [notes]
 
+[notes.patches]
+    title = "Patches"
+        description = """\
+CABPT now supports Talos Linux machine configuration strategic merge patches via 'strategicPatches' field on the `TalosConfig` CRD.
+"""


### PR DESCRIPTION
This commit implements strategic merge patch by reusing talos StrategicMergePatch implementation. Additionally, it adds an integration test for strategic merge patches.

Fixes https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/issues/181.