### PR TITLE
fix: use net.JoinHostPort for control plane endpoint URL

### DIFF
--- a/controllers/talosconfig_controller.go
+++ b/controllers/talosconfig_controller.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -512,7 +513,7 @@ func (r *TalosConfigReconciler) genConfigs(ctx context.Context, scope *TalosConf
 
 	input, err := generate.NewInput(
 		scope.Cluster.Name,
-		"https://"+scope.Cluster.Spec.ControlPlaneEndpoint.Host+":"+APIEndpointPort,
+		"https://"+net.JoinHostPort(scope.Cluster.Spec.ControlPlaneEndpoint.Host, APIEndpointPort),
 		k8sVersion,
 		genOptions...,
 	)


### PR DESCRIPTION
Use net.JoinHostPort to create endpoint URL, as this covers also the IPv6 address case, where the address needs to be enclosed in brackets. Otherwise use of IPv6 endpoint IPs will lead to an error.