### PR TITLE
fix: apiGroup for MachinePool

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,17 +41,10 @@ rules:
   resources:
   - clusters
   - clusters/status
-  - machines
-  - machines/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - exp.cluster.x-k8s.io
-  resources:
   - machinepools
   - machinepools/status
+  - machines
+  - machines/status
   verbs:
   - get
   - list

--- a/controllers/talosconfig_controller.go
+++ b/controllers/talosconfig_controller.go
@@ -124,7 +124,7 @@ func (r *TalosConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 // +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=talosconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=talosconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status;machines;machines/status,verbs=get;list;watch
-// +kubebuilder:rbac:groups=exp.cluster.x-k8s.io,resources=machinepools;machinepools/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools;machinepools/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 func (r *TalosConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {


### PR DESCRIPTION
Small fix for MachinePool API group to resolve rbac errors, i.e. https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/issues/219