### PR TITLE
fix: bypass immutability check for topology dry-run

### DIFF
--- a/api/v1beta1/talosconfig_webhook.go
+++ b/api/v1beta1/talosconfig_webhook.go
@@ -12,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/cluster-api/util/topology"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -37,7 +38,13 @@ func (r *TalosConfig) ValidateUpdate(ctx context.Context, oldObj *TalosConfig, n
 	old := oldObj
 	r = newObj
 
-	if !cmp.Equal(r.Spec, old.Spec) {
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Skip the immutability check if the request is a dry-run issued by the topology controller (#257)
+	if !topology.IsDryRunRequest(req, r) && !cmp.Equal(r.Spec, old.Spec) {
 		return nil, apierrors.NewBadRequest("TalosConfig.Spec is immutable")
 	}
 

--- a/api/v1beta1/talosconfigtemplate_webhook.go
+++ b/api/v1beta1/talosconfigtemplate_webhook.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/cluster-api/util/topology"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -33,7 +34,13 @@ func (r *TalosConfigTemplate) ValidateUpdate(ctx context.Context, oldObj *TalosC
 	old := oldObj
 	r = newObj
 
-	if !cmp.Equal(r.Spec, old.Spec) {
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Skip the immutability check if the request is a dry-run issued by the topology controller (#257)
+	if !topology.IsDryRunRequest(req, r) && !cmp.Equal(r.Spec, old.Spec) {
 		return nil, apierrors.NewBadRequest("TalosConfigTemplate.Spec is immutable")
 	}
 


### PR DESCRIPTION
This PR fixes #257

Dry-run requests made by the topology controller get blocked by the immutability check, which blocks the topology controller from rotating the TalosConfigTemplate during upgrades.

This does not break the immutability check; all other requests get blocked, and the dry-run request from the topology controller does not write anything. The topology controller will rotate the TalosConfigTemplate, not update it.

Release is provided at https://github.com/stingalleman/cluster-api-bootstrap-provider-talos/releases/tag/v0.7.0-alpha.4 for testing purposes